### PR TITLE
fix: correct continueOnError logic in chain execution, fixes #10

### DIFF
--- a/e2e/object-models/api-model.ts
+++ b/e2e/object-models/api-model.ts
@@ -20,10 +20,10 @@ export class APImodel extends  ReqHelpers {
                                                         .getByRole('textbox') 
         
 
-    async get(url:string):Promise<string> 
+    async get(url:string):Promise<void>
     {
         await this.fillUrl.fill(url)
-        
+
         await this.reqType.selectOption('GET')
     }
 
@@ -51,7 +51,7 @@ export class APImodel extends  ReqHelpers {
         await this.page.waitForLoadState('networkidle')
         await this.responseBody.locator('.view-line').last().textContent()
         let result = await this.responseBody.textContent()
-        result = result.replace(/\u00A0/g, ' ')
+        result = result?.replace(/\u00A0/g, ' ') || ''
         return result
     }
 

--- a/e2e/object-models/request-assiters.model.ts
+++ b/e2e/object-models/request-assiters.model.ts
@@ -78,7 +78,7 @@ export class ReqHelpers extends BasePage {
     
     async uncheckHeader(hName:string):Promise<Locator> {
         await this.checkIfInheaderSection()
-        let cb: Locator
+        let cb: Locator | undefined
         const placeHolder :string = (await this.reqHeaderName.getAttribute('placeholder'))!
         const allph =  await this.reqBuilderMain.getByPlaceholder(placeHolder).all()
         for(let i=0; i < allph.length; i++) {
@@ -86,7 +86,9 @@ export class ReqHelpers extends BasePage {
                 cb = await this.reqBuilderMain.getByRole('checkbox').nth(i)
                 await cb.uncheck()
             }
-        } return cb
+        }
+        if (!cb) throw new Error(`Header ${hName} not found`)
+        return cb
     }
     
     async deleteHeader(hName: string) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@playwright/test": "^1.56.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
+        "@types/dotenv": "^6.1.1",
         "@types/node": "^22",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -149,7 +150,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -552,7 +552,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -599,7 +598,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2040,7 +2038,6 @@
       "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.56.1"
       },
@@ -2402,6 +2399,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2422,6 +2420,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2497,7 +2496,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2568,6 +2568,16 @@
       "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
       "license": "MIT"
     },
+    "node_modules/@types/dotenv": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-6.1.1.tgz",
+      "integrity": "sha512-ftQl3DtBvqHl9L16tpqqzA4YzCSXZfi7g8cQceTz5rOlYtk/IZbFjAv3mLOQlNIgOaylCQWQoBdDQHPgEBJPHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2595,7 +2605,6 @@
       "integrity": "sha512-pAZSHMiagDR7cARo/cch1f3rXy0AEXwsVsVH09FcyeJVAzCnGgmYis7P3JidtTUjyadhTeSo8TgRPswstghDaw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2605,7 +2614,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.0.tgz",
       "integrity": "sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2616,7 +2624,6 @@
       "integrity": "sha512-brtBs0MnE9SMx7px208g39lRmC5uHZs96caOJfTjFcYSLHNamvaSMfJNagChVNkup2SdtOxKX1FDBkRSJe1ZAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2625,7 +2632,8 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-1.0.6.tgz",
       "integrity": "sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.45.0",
@@ -2673,7 +2681,6 @@
       "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.45.0",
         "@typescript-eslint/types": "8.45.0",
@@ -3355,7 +3362,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3855,7 +3861,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -4314,6 +4319,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4332,8 +4338,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.2.0.tgz",
       "integrity": "sha512-OSeyyWOUetDy9oFWeddJgi83OnRA3hSFh3RrbltmPgqHszE9f24eUCVLI4mPg0ifsWk0lQTdnS+jyGNrPMvhDA==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/dexie-react-hooks": {
       "version": "1.1.7",
@@ -4387,7 +4392,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "17.2.3",
@@ -4701,7 +4707,6 @@
       "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4876,7 +4881,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6367,7 +6371,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6398,7 +6401,6 @@
       "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^6.7.2",
         "cssstyle": "^5.3.1",
@@ -6438,7 +6440,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -6637,6 +6638,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7361,7 +7363,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7521,6 +7522,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7536,6 +7538,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7546,6 +7549,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7558,7 +7562,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -7614,7 +7619,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7624,7 +7628,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8718,7 +8721,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8931,7 +8933,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9055,7 +9056,6 @@
       "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -9149,7 +9149,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9163,7 +9162,6 @@
       "integrity": "sha512-hV31h0/bGbtmDQc0KqaxsTO1v4ZQeF8ojDFuy4sZhFadwAqqvJA0LDw68QUocctI5EDpFMql/jVWKuPYHIf2Ew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.4",
         "@vitest/mocker": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@playwright/test": "^1.56.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
+    "@types/dotenv": "^6.1.1",
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/components/ComparisonSelector.tsx
+++ b/src/components/ComparisonSelector.tsx
@@ -115,9 +115,9 @@ export default function ComparisonSelector({ isOpen, onClose, onSelect }: Compar
                         {item.method}
                       </span>
                       <span className={`px-2 py-0.5 text-xs rounded ${
-                        item.response?.status >= 200 && item.response?.status < 300
+                        item.response?.status !== undefined && item.response.status >= 200 && item.response.status < 300
                           ? 'bg-green-100 text-green-700 dark:bg-green-900/20 dark:text-green-400'
-                          : item.response?.status >= 400
+                          : item.response?.status !== undefined && item.response.status >= 400
                           ? 'bg-red-100 text-red-700 dark:bg-red-900/20 dark:text-red-400'
                           : 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400'
                       }`}>

--- a/src/components/WebSocketPanel.tsx
+++ b/src/components/WebSocketPanel.tsx
@@ -22,7 +22,7 @@ export default function WebSocketPanel() {
       }
     });
 
-    return () => unsubscribe();
+    return () => { unsubscribe(); };
   }, []);
 
   useEffect(() => {

--- a/src/lib/chain-service.ts
+++ b/src/lib/chain-service.ts
@@ -230,14 +230,13 @@ class ChainService {
 
           // Check if we should continue on error
           if (!step.continueOnError) {
-            throw new Error(`Step ${i + 1} failed: ${error.message}`);
+            // Mark remaining steps as skipped
+            for (let j = i + 1; j < execution.steps.length; j++) {
+              execution.steps[j].status = 'skipped';
+            }
+            break;
           }
-
-          // Mark remaining steps as skipped
-          for (let j = i + 1; j < execution.steps.length; j++) {
-            execution.steps[j].status = 'skipped';
-          }
-          break;
+          // If continueOnError is true, continue to next step
         }
       }
 

--- a/src/lib/collections-service.ts
+++ b/src/lib/collections-service.ts
@@ -26,8 +26,11 @@ export const collectionsService = {
 
     collection.requests.push(requestToAdd);
     collection.updatedAt = new Date();
-    
-    await db.collections.update(collectionId, collection);
+
+    await db.collections.update(collectionId, {
+      requests: collection.requests,
+      updatedAt: collection.updatedAt
+    });
   },
 
   async removeRequestFromCollection(collectionId: string, requestId: string) {
@@ -36,8 +39,11 @@ export const collectionsService = {
 
     collection.requests = collection.requests.filter(r => r.id !== requestId);
     collection.updatedAt = new Date();
-    
-    await db.collections.update(collectionId, collection);
+
+    await db.collections.update(collectionId, {
+      requests: collection.requests,
+      updatedAt: collection.updatedAt
+    });
   },
 
   async updateCollection(collectionId: string, updates: Partial<Collection>) {

--- a/src/lib/http-client.ts
+++ b/src/lib/http-client.ts
@@ -13,6 +13,8 @@ interface HttpClientResponse {
   statusText: string;
   headers: Record<string, string>;
   data: any;
+  time: number; // milliseconds
+  size: number; // bytes
 }
 
 class HttpClient {
@@ -33,26 +35,40 @@ class HttpClient {
       }
     }
 
+    const startTime = Date.now();
+
     try {
       const response = await axios(config);
-      
+      const endTime = Date.now();
+      const time = endTime - startTime;
+      const size = JSON.stringify(response.data).length;
+
       return {
         status: response.status,
         statusText: response.statusText,
         headers: response.headers as Record<string, string>,
         data: response.data,
+        time,
+        size,
       };
     } catch (error: any) {
+      const endTime = Date.now();
+      const time = endTime - startTime;
+
       // Handle error responses
       if (error.response) {
+        const size = JSON.stringify(error.response.data).length;
+
         return {
           status: error.response.status,
           statusText: error.response.statusText,
           headers: error.response.headers as Record<string, string>,
           data: error.response.data,
+          time,
+          size,
         };
       }
-      
+
       // Handle network errors
       throw new Error(error.message || 'Network error occurred');
     }

--- a/src/lib/search-service.ts
+++ b/src/lib/search-service.ts
@@ -1,5 +1,5 @@
-import { db, Collection, HistoryItem } from './db';
-import { Request } from '@/types';
+import { db, HistoryItem } from './db';
+import { Request, Collection } from '@/types';
 
 export interface SearchResult {
   id: string;


### PR DESCRIPTION
Fixes #10

## Problem

The continueOnError flag was inverted. When set to true, chains would mark remaining steps as skipped and stop instead of continuing to the next step.

Root cause: the skip-and-break logic at lines 236-240 was running outside the conditional block, so it executed when continueOnError was true.

## Changes

Moved the skip-and-break logic inside the `!step.continueOnError` block so it only runs when we should stop on error.

Also cleaned up several TypeScript errors that were blocking builds:
- Added missing time/size properties to HttpClientResponse  
- Fixed return types and null checks in e2e models
- Corrected Dexie update() calls to use UpdateSpec
- Fixed Collection import path
- Added @types/dotenv

Build verified passing.