### PR TITLE
fix: throw error instead of silent return in cancelExecution, fixes #11

### DIFF
--- a/src/lib/chain-service.ts
+++ b/src/lib/chain-service.ts
@@ -306,7 +306,12 @@ class ChainService {
    */
   async cancelExecution(executionId: string): Promise<void> {
     const execution = await this.getExecution(executionId);
-    if (!execution || execution.status !== 'running') return;
+    if (!execution) {
+      throw new Error(`Execution ${executionId} not found`);
+    }
+    if (execution.status !== 'running') {
+      throw new Error(`Cannot cancel execution with status: ${execution.status}`);
+    }
 
     execution.status = 'cancelled';
     execution.completedAt = new Date();


### PR DESCRIPTION
Fixes #11

## Problem

cancelExecution would silently return when the execution didn't exist or wasn't in running status. No error, no feedback - just nothing. Makes debugging issues nearly impossible.

## Changes

Replaced the silent return with proper error throwing:
- Execution not found: `Error: Execution {id} not found`
- Wrong status: `Error: Cannot cancel execution with status: {status}`

## Notes

Issue #13 (persistence) is already handled by the existing `db.chainExecutions.update()` call - cancellation is being persisted correctly.