### PR TITLE
fix: use setChainVariables instead of merge for deletion, fixes #39

### DIFF
--- a/e2e/tests/main-components/requestBuilder.component.spec.ts
+++ b/e2e/tests/main-components/requestBuilder.component.spec.ts
@@ -164,8 +164,7 @@ test('add chain variable', async({page, apiReq}) => {
 
 test('delete chain varaible', async({preVariables, apiReq}) => {
     await apiReq.chainVariableDelete('chainVar1')
-    //below test is failing so i have put visisble for now
-    await expect(apiReq.reqBuilderMain.getByText('chainVar1')).toBeVisible()
+    await expect(apiReq.reqBuilderMain.getByText('chainVar1')).not.toBeVisible()
 })
 
 test('chain variables clear all', async({apiReq, preVariables}) => {

--- a/src/components/VariablesPanel.tsx
+++ b/src/components/VariablesPanel.tsx
@@ -14,7 +14,7 @@ interface ConfirmDialog {
 }
 
 export default function VariablesPanel() {
-  const { chainVariables, mergeChainVariables, clearChainVariables } = useStore();
+  const { chainVariables, mergeChainVariables, setChainVariables, clearChainVariables } = useStore();
   const [scriptVariables, setScriptVariables] = useState<Map<string, any>>(new Map());
   const [editingKey, setEditingKey] = useState<string | null>(null);
   const [editingValue, setEditingValue] = useState<string>('');
@@ -91,7 +91,7 @@ export default function VariablesPanel() {
         if (activeSource === 'chain') {
           const newVars = { ...chainVariables };
           delete newVars[key];
-          mergeChainVariables(newVars);
+          setChainVariables(newVars);
         } else {
           scriptingService.deleteVariable(key);
           loadScriptVariables();


### PR DESCRIPTION
Fixes #39

## Problem

Deleting chain variables didn't work. The UI would show them gone, but they'd come back on refresh.

Root cause: mergeChainVariables merges the new variables with the old state, so deleted keys get re-added from the old state.

## Changes

Use setChainVariables instead of mergeChainVariables when deleting. setChainVariables replaces the entire object, so deletions actually stick.