### PR TITLE
fix: normalize undefined to null and replace placeholders, fixes #14 #15

### DIFF
--- a/src/lib/variable-extraction-service.ts
+++ b/src/lib/variable-extraction-service.ts
@@ -40,7 +40,8 @@ class VariableExtractionService {
           wrap: false,
         });
 
-        extracted[extraction.name] = result;
+        // Normalize undefined to null for consistency
+        extracted[extraction.name] = result === undefined ? null : result;
       } catch (error) {
         console.error(`Failed to extract variable ${extraction.name}:`, error);
         extracted[extraction.name] = null;
@@ -78,10 +79,14 @@ class VariableExtractionService {
       
       // Support nested paths like {{user.id}}
       const value = this.getNestedValue(variables, trimmedName);
-      
-      if (value === undefined || value === null) {
+
+      if (value === undefined) {
         console.warn(`Variable ${trimmedName} not found`);
-        return match; // Keep original if not found
+        return 'undefined';
+      }
+
+      if (value === null) {
+        return 'null';
       }
 
       return String(value);


### PR DESCRIPTION
Fixes #14, #15

## Problems

Two related bugs in variable extraction:

1. **undefined vs null**: extractVariables could store `undefined` when JSONPath finds nothing, but the error case stores `null`. Inconsistent.

2. **Placeholder retention**: When interpolating variables, `{{placeholder}}` syntax was kept in the output when variables were undefined/null. Makes it impossible to distinguish between actual placeholder syntax and missing variables.

## Changes

- Normalize JSONPath `undefined` results to `null` 
- Replace undefined variables with the string `'undefined'`
- Replace null variables with the string `'null'`

Now variable values are consistent and placeholders actually get replaced.